### PR TITLE
회원가입, 로그인 연동

### DIFF
--- a/frontend/src/Model/UserModel.tsx
+++ b/frontend/src/Model/UserModel.tsx
@@ -1,17 +1,16 @@
 import React, { createContext, useContext, useState, Dispatch, useEffect } from 'react';
 import { childrenObj, User } from '../utils/types';
 
-const UserState = createContext<User | undefined>(undefined);
-const UserDispatch = createContext<Dispatch<User>>(() => {});
+const UserState = createContext<User | undefined | string>(undefined);
+const UserDispatch = createContext<Dispatch<User | string>>(() => {});
 const HeaderState = createContext('');
 const HeaderDispatch = createContext<Dispatch<string>>(() => {});
 
 export const UserContextProvider = ({ children }: childrenObj) => {
-	const [user, setUser] = useState<User | undefined>(undefined);
+	const [user, setUser] = useState<User | undefined | string>(undefined);
 	const [header, setHeader] = useState('');
 
 	useEffect(() => { // try login if browser has cookie
-
 	}, []);
 	return (
 		<UserState.Provider value={user}>

--- a/frontend/src/Model/UserModel.tsx
+++ b/frontend/src/Model/UserModel.tsx
@@ -45,4 +45,3 @@ export function useHeaderDispatch() {
 	const context = useContext(HeaderDispatch);
 	return context;
 }
-

--- a/frontend/src/Provider.tsx
+++ b/frontend/src/Provider.tsx
@@ -2,13 +2,16 @@ import React from 'react';
 import { PlaceContextProvider } from './Model/PlaceModel';
 import { PlaceLogicProvider } from './ViewModel';
 import Router from "./routes";
+import { UserContextProvider } from './Model/UserModel';
 
 const Provider : React.FC = () => (
-	<PlaceContextProvider>
-		<PlaceLogicProvider>
-			<Router />
-		</PlaceLogicProvider>
-	</PlaceContextProvider>
+	<UserContextProvider>
+		<PlaceContextProvider>
+			<PlaceLogicProvider>
+				<Router />
+			</PlaceLogicProvider>
+		</PlaceContextProvider>
+	</UserContextProvider>
 );
 
 export default Provider;

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,13 +1,16 @@
 // Header Component
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
 
 import { Grid, Menu, MenuItem } from "@material-ui/core";
 import KeyboardArrowDownIcon from "@material-ui/icons/KeyboardArrowDown";
 import { SignIn } from ".";
+import { useUserState } from "../Model/UserModel";
 
 interface Props { }
 const Header: React.FunctionComponent<Props> = () => {
+	const User = useUserState();
+	console.log(User);
 	const name = "홍길동";
 	const [isLogined, setIsLogined] = useState<boolean>(false);
 	const [open, setOpen] = useState<boolean>(false);
@@ -20,6 +23,10 @@ const Header: React.FunctionComponent<Props> = () => {
 	const handleClose = () => {
 		setAnchorEl(null);
 	};
+
+	useEffect(() => {
+		if (User !== undefined) setIsLogined(true);
+	}, [User]);
 
 	return (
 		<Grid className="header">

--- a/frontend/src/components/Register.tsx
+++ b/frontend/src/components/Register.tsx
@@ -261,11 +261,9 @@ const Register: React.FunctionComponent<Props> = ({ ropen, closeHandler }) => {
 						password: pw,
 						email
 					});
-					console.log(result.data);
-					// status pending시 처리하기
-					// 정답 응답시 넘어가게 하기
+					setActiveStep((prevActiveStep) => prevActiveStep + 1);
 				} catch (err) {
-					console.log(err);
+					alert(err.response.data);
 				}
 			}
 		}

--- a/frontend/src/components/SignIn.tsx
+++ b/frontend/src/components/SignIn.tsx
@@ -16,8 +16,10 @@ import CloseIcon from '@material-ui/icons/Close';
 import { Register } from ".";
 import "../css/Login.scss";
 import { API_URL } from "../utils/CommonVariables";
+import { useHeaderDispatch } from "../Model/UserModel";
 
 const SignIn: React.FunctionComponent = () => {
+	const setHeader = useHeaderDispatch();
 	const [Open, setOpen] = useState(false);
 	const [ropen, setRopen] = useState(false);
 	const [id, setId] = useState('');
@@ -44,6 +46,8 @@ const SignIn: React.FunctionComponent = () => {
 				password: pw
 			});
 			console.log(result); // setHeader 하기~
+			setHeader(result.data.token);
+			handleClose();
 		} catch (err) {
 			console.log(err);
 			alert('로그인에 실패했습니다.');

--- a/frontend/src/components/SignIn.tsx
+++ b/frontend/src/components/SignIn.tsx
@@ -16,10 +16,11 @@ import CloseIcon from '@material-ui/icons/Close';
 import { Register } from ".";
 import "../css/Login.scss";
 import { API_URL } from "../utils/CommonVariables";
-import { useHeaderDispatch } from "../Model/UserModel";
+import { useHeaderDispatch, useUserDispatch } from "../Model/UserModel";
 
 const SignIn: React.FunctionComponent = () => {
 	const setHeader = useHeaderDispatch();
+	const setUser = useUserDispatch();
 	const [Open, setOpen] = useState(false);
 	const [ropen, setRopen] = useState(false);
 	const [id, setId] = useState('');
@@ -47,6 +48,7 @@ const SignIn: React.FunctionComponent = () => {
 			});
 			console.log(result); // setHeader 하기~
 			setHeader(result.data.token);
+			setUser(id);
 			handleClose();
 		} catch (err) {
 			console.log(err);


### PR DESCRIPTION
* 회원가입시 오류 안뜨면 마지막 단계가 보이도록 함 ( 현재 css 깨짐 )
  * 중복확인 아직 연동 x( 근데 어차피 중복이면 오류뜸...ㅋㅋㅋ )
* 로그인 시 성공하면 userModel의 header에 토큰저장, user에는 그냥 userid 저장함.
  * 어떻게 할까염..?